### PR TITLE
Select: rename param onSelect to onSelectChange, add name param in on SelectChange, add controlled select on stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensearena/ui",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/components/inputs/Select.tsx
+++ b/src/components/inputs/Select.tsx
@@ -58,11 +58,8 @@ export function Select<TOption>({
     [onChangeSelect],
   );
 
-  const formatSelectValue = (value: TOption) => {
-    return typeof value === 'number' || typeof value === 'string' ? value : String(value);
-  };
-
-  const valueForSelect = formatSelectValue(selectedOption);
+  const valueForSelect =
+    typeof selectedOption === 'number' || typeof selectedOption === 'string' ? selectedOption : String(selectedOption);
 
   return (
     <>

--- a/src/components/inputs/Select.tsx
+++ b/src/components/inputs/Select.tsx
@@ -9,7 +9,7 @@ import { DropDownMenu } from '../dropdown-menu';
 type Props<TOption> = {
   disabled?: boolean;
   error?: boolean;
-  onSelect?: (selected: TOption) => void;
+  onChangeSelect?: (selected: TOption, name?: string) => void;
   selectedOptionLabel: string;
   selectedOption: TOption;
   options: {
@@ -25,7 +25,7 @@ type Props<TOption> = {
 
 export function Select<TOption>({
   disabled,
-  onSelect,
+  onChangeSelect,
   selectedOptionLabel,
   options,
   error,
@@ -52,14 +52,17 @@ export function Select<TOption>({
 
   const selectItem = useCallback(
     (optionValue: TOption) => {
-      onSelect?.(optionValue);
+      onChangeSelect?.(optionValue, rest.name);
       close();
     },
-    [onSelect],
+    [onChangeSelect],
   );
 
-  const valueForSelect =
-    typeof selectedOption === 'number' || typeof selectedOption === 'string' ? selectedOption : String(selectedOption);
+  const formatSelectValue = (value: TOption) => {
+    return typeof value === 'number' || typeof value === 'string' ? value : String(value);
+  };
+
+  const valueForSelect = formatSelectValue(selectedOption);
 
   return (
     <>

--- a/src/stories/inputs/Select.stories.tsx
+++ b/src/stories/inputs/Select.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Select } from '../../components/inputs';
+import { useState } from 'react';
 
 export default {
   title: 'UI/Inputs/Select',
@@ -34,13 +35,32 @@ const options = [
   },
 ];
 
-const Template: ComponentStory<typeof Select<string>> = args => <Select<string> {...args} />;
+const Template: ComponentStory<typeof Select> = args => <Select {...args} />;
+
+const ControlledTemplate: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState(options[0].value);
+  return (
+    <Select
+      border="grey"
+      fullWidth
+      name="controlled"
+      selectedOption={value}
+      selectedOptionLabel={options.find(item => item.value === value)?.title ?? 'Select option'}
+      options={options}
+      onChangeSelect={(value, name) => {
+        setValue(value);
+        console.log(value);
+        console.log(name);
+      }}
+    />
+  );
+};
 
 export const Base = Template.bind({});
 Base.args = {
   selectedOption: '1',
   selectedOptionLabel: '1',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   options,
   border: 'grey',
   label: 'Title',
@@ -50,7 +70,7 @@ LongValue.args = {
   selectedOption: '1',
   selectedOptionLabel:
     'Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey Sense Arena Hockey',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   label: 'Title',
   options,
 };
@@ -59,7 +79,7 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   selectedOption: '1',
   selectedOptionLabel: 'Sense Arena Hockey dsfsdkf ',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   label: 'Title',
   options,
   disabled: true,
@@ -69,7 +89,7 @@ export const Error = Template.bind({});
 Error.args = {
   selectedOption: '1',
   selectedOptionLabel: 'Sense Arena Hockey dsfsdkf ',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   label: 'Title',
   options,
   error: true,
@@ -80,7 +100,7 @@ export const Small = Template.bind({});
 Small.args = {
   selectedOption: '1',
   selectedOptionLabel: 'Sense Arena Hockey dsfsdkf ',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   options,
   border: 'grey',
 };
@@ -89,7 +109,7 @@ export const Large = Template.bind({});
 Large.args = {
   selectedOption: '1',
   selectedOptionLabel: 'Sense Arena Hockey dsfsdkf ',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   options,
   border: 'grey',
 };
@@ -98,9 +118,11 @@ export const FullWidth = Template.bind({});
 FullWidth.args = {
   selectedOption: '1',
   selectedOptionLabel: 'Sense Arena Hockey dsfsdkf ',
-  onSelect: console.debug,
+  onChangeSelect: console.debug,
   options,
   border: 'grey',
   fullWidth: true,
   name: 'select',
 };
+
+export const Controlled = ControlledTemplate.bind({});


### PR DESCRIPTION
Переименовал onSelect на onSelectChange, потому что есть стандартный onSelect тип, они конфликтовали
Добавил name в onSelectChange чтоб было легче ориентироваться при множестве селектов на странице